### PR TITLE
Add host properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## Dradis Framework 3.XX (XXX, 2020) ##
+## Dradis Framework 3.20 (XXX, 2020) ##
 
 *  Initial version.

--- a/lib/dradis/plugins/nipper/gem_version.rb
+++ b/lib/dradis/plugins/nipper/gem_version.rb
@@ -7,7 +7,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 19
+        MINOR = 20
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/nipper/importer.rb
+++ b/lib/dradis/plugins/nipper/importer.rb
@@ -72,6 +72,12 @@ module Dradis::Plugins::Nipper
         label: host_xml.attr('name'),
         type: :host
       )
+
+      # Set device properties
+      @host_node.set_property(:device_name, host_xml.attr('name'))
+      @host_node.set_property(:device_type, host_xml.attr('type'))
+      @host_node.set_property(:os_version, host_xml.attr('osversion'))
+      @host_node.save
     end
   end
 end

--- a/spec/upload_spec.rb
+++ b/spec/upload_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'Nipper upload plugin' do
   describe 'importer' do
@@ -23,14 +23,14 @@ describe 'Nipper upload plugin' do
         OpenStruct.new(args)
       end.once
 
-      @importer.import(file: 'spec/fixtures/files/invalid.xml')
+      @importer.import(file: File.expand_path('../spec/fixtures/files/invalid.xml', __dir__))
     end
 
     it 'creates nodes, issues, and evidences as needed' do
       expect(@content_service).to receive(:create_node) do |args|
         expect(args[:label]).to eq('PA-200')
         expect(args[:type]).to eq(:host)
-        OpenStruct.new(args)
+        @node = Node.create(label: args[:label])
       end.once
       expect(@content_service).to receive(:create_issue) do |args|
         OpenStruct.new(args)
@@ -40,7 +40,15 @@ describe 'Nipper upload plugin' do
       end.exactly(2).times
 
       # Run the import
-      @importer.import(file: 'spec/fixtures/files/sample.xml')
+      @importer.import(file: File.expand_path('../spec/fixtures/files/sample.xml', __dir__))
+
+      expect(@node.properties).to eq(
+        {
+          'device_name'=>'PA-200',
+          'device_type'=>'Palo Alto Firewall',
+          'os_version'=>'7.0.0'
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
### Spec
Currently, we're not adding the device properties for the imported host in the Nipper upload plugin.

Example device:

```
<devices>
  <device name="PA-200" type="Palo Alto Firewall" os="PANOS" osversion="7.0.0" />
</devices>
```

**Proposed solution**
Set the above properties in the Nipper importer.

### How to test
1. Install the Nipper branch in your instance.
2. Upload the sample file from the Nipper repository.
3. Confirm that the imported Host has the properties.