### PR TITLE
Include all text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-## Dradis Framework 3.20 (XXX, 2020) ##
+## Dradis Framework 3.21 (XXX, 2021) ##
+
+*  Include multiple paragraphs when importing fields.
+
+## Dradis Framework 3.20 (January, 2021) ##
 
 *  Initial version.

--- a/lib/dradis/plugins/nipper/gem_version.rb
+++ b/lib/dradis/plugins/nipper/gem_version.rb
@@ -6,8 +6,8 @@ module Dradis
       end
 
       module VERSION
-        MAJOR = 3
-        MINOR = 22
+        MAJOR = 4
+        MINOR = 0
         TINY = 0
         PRE = nil
 

--- a/lib/nipper/issue.rb
+++ b/lib/nipper/issue.rb
@@ -41,7 +41,7 @@ module Nipper
       elsif method.to_s.starts_with?('cvss')
         process_cvss_field(method)
       else
-        @xml.xpath("./#{translations_table[method]}").first.try(:text)
+        collect_text(@xml.xpath("./#{translations_table[method]}"))
       end
     end
 
@@ -55,10 +55,16 @@ module Nipper
       base_method = method.to_s.sub('_vector', '').to_sym
 
       if method.to_s.ends_with?('vector')
-        @xml.xpath("./#{translations_table[base_method]}").first.try(:text)
+        collect_text(@xml.xpath("./#{translations_table[base_method]}"))
       else
         @xml.xpath("./#{translations_table[base_method]}").attr('score')
       end
+    end
+
+    private
+
+    def collect_text(xml_field)
+      xml_field.children.map { |xml_text| xml_text.text }.join("\n")
     end
   end
 end

--- a/spec/upload_spec.rb
+++ b/spec/upload_spec.rb
@@ -34,6 +34,7 @@ describe 'Nipper upload plugin' do
       end.once
       expect(@content_service).to receive(:create_issue) do |args|
         OpenStruct.new(args)
+        @issue = Issue.create(text: args[:text])
       end.exactly(2).times
       expect(@content_service).to receive(:create_evidence) do |args|
         OpenStruct.new(args)
@@ -49,6 +50,8 @@ describe 'Nipper upload plugin' do
           'os_version'=>'7.0.0'
         }
       )
+
+      expect(@issue.fields['Finding'].lines.count).to eq(2)
     end
   end
 end


### PR DESCRIPTION
### Spec
Currently, when uploading a file from the Nipper plugin, `dradis-nipper` only fetches the first paragraph from a field.

Example XML:

```
<section index="2.4.1" title="Finding" ref="FINDING">
          <text>Lorem ipsum</text>
          <text>Lorem ipsum</text>
<.....>
```

In this case the two <text> markups needs to be fetched.

**Proposed solution**
Update the xpath in the `lib/nipper/issue.rb` file to fetch all the text elements.

### How to test:
1. Upload a sample nipper xml file.
2. Confirm that all the text were uploaded in the fields