### PR TITLE
Add SECURITY.FINDINGS.SUMMARY to the ignored sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.4.0 (XXX 2022)
+  - Ignore the findings summary section during import
+
 v4.4.0 (June 2022)
   - No changes
 

--- a/lib/dradis/plugins/nipper/importer.rb
+++ b/lib/dradis/plugins/nipper/importer.rb
@@ -2,6 +2,7 @@ module Dradis::Plugins::Nipper
   class Importer < Dradis::Plugins::Upload::Importer
     SECURITY_SECTIONS = %w{
       SECURITY.INTRODUCTION
+      SECURITY.FINDINGS.SUMMARY
       SECURITY.CONCLUSIONS
       SECURITY.RECOMMENDATIONS
       SECURITY.MITIGATIONS


### PR DESCRIPTION
### Spec
Nipper v2.13 (or earlier) introduced the "SECURITY.FINDINGS.SUMMARY" section that needs to be ignored. Otherwise, the importer sees it as a vulnerability rather than an informational section.

**Proposed solution**
Add SECURITY.FINDINGS.SUMMARY to the ignored sections list.